### PR TITLE
feat: OpenCode integration — install.sh, sync, convert (#5)

### DIFF
--- a/scripts/convert-to-opencode.py
+++ b/scripts/convert-to-opencode.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Convert OpenSIN-Skills for different AI editors.
+Usage: python3 convert-to-opencode.py . --target opencode
+Stdlib-only. Author: OpenSIN-AI. License: MIT."""
+import argparse, json, os, sys
+
+def find_skills(root):
+    skills = []
+    for dp, dns, fns in os.walk(root):
+        dns[:] = [d for d in dns if not d.startswith(".") and d != "node_modules"]
+        if "SKILL.md" in fns: skills.append(os.path.relpath(dp, root))
+    return sorted(skills)
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("root", help="Root directory")
+    p.add_argument("--target", "-t", default="opencode", choices=["opencode","cursor","aider"])
+    p.add_argument("--output", "-o")
+    a = p.parse_args()
+    skills = find_skills(a.root)
+    print(f"Found {len(skills)} skills", file=sys.stderr)
+    if a.target == "opencode":
+        r = json.dumps({"name":"OpenSIN-Skills","skills":{"path":a.root},"total":len(skills)}, indent=2)
+    elif a.target == "cursor":
+        r = "# OpenSIN-Skills\n" + "\n".join(f"- {os.path.basename(s)}: {s}/SKILL.md" for s in skills[:50])
+    else:
+        r = f"# OpenSIN-Skills ({len(skills)} skills)"
+    if a.output:
+        with open(a.output,"w") as f: f.write(r+"\n")
+    else: print(r)
+
+if __name__ == "__main__": main()

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# install.sh — Install OpenSIN-Skills into OpenCode environment
+# Usage: bash scripts/install.sh [--all|--operations|--knowledge|--help]
+# Author: OpenSIN-AI | License: MIT
+set -euo pipefail
+SKILLS_REPO="https://github.com/OpenSIN-AI/OpenSIN-Skills.git"
+INSTALL_DIR="${HOME}/.local/share/opensin-skills"
+OPENCODE_SKILLS="${HOME}/.config/opencode/skills"
+log() { echo "[OpenSIN] $*"; }
+MODE="all"
+for arg in "$@"; do case "$arg" in --operations) MODE="operations";; --knowledge) MODE="knowledge";; --help|-h) echo "Usage: install.sh [--all|--operations|--knowledge|--help]"; exit 0;; esac; done
+mkdir -p "${OPENCODE_SKILLS}"
+if [ -d "${INSTALL_DIR}/.git" ]; then
+  log "Updating..."; cd "${INSTALL_DIR}" && git pull --ff-only 2>/dev/null || { rm -rf "${INSTALL_DIR}"; git clone --depth 1 "${SKILLS_REPO}" "${INSTALL_DIR}"; }
+else
+  log "Cloning..."; mkdir -p "$(dirname "${INSTALL_DIR}")"; git clone --depth 1 "${SKILLS_REPO}" "${INSTALL_DIR}"
+fi
+COUNT=0
+link_skills() { local d="$1"; [ -d "${INSTALL_DIR}/${d}" ] || return; while IFS= read -r f; do local sd; sd="$(dirname "$f")"; local n; n="$(basename "$sd")"; ln -sf "$sd" "${OPENCODE_SKILLS}/${n}"; COUNT=$((COUNT+1)); done < <(find "${INSTALL_DIR}/${d}" -name "SKILL.md" -type f 2>/dev/null); }
+case "$MODE" in
+  all) for d in engineering product-team marketing-skill c-level-advisor project-management ra-qm-team business-growth finance; do link_skills "$d"; done; for c in agent-creation browser-automation deployment media planning documents google misc; do link_skills "operations/$c"; done;;
+  operations) for c in agent-creation browser-automation deployment media planning documents google misc; do link_skills "operations/$c"; done;;
+  knowledge) for d in engineering product-team marketing-skill c-level-advisor project-management ra-qm-team business-growth finance; do link_skills "$d"; done;;
+esac
+log "Done! ${COUNT} skills installed to ${OPENCODE_SKILLS}"

--- a/scripts/sin-sync-skills.sh
+++ b/scripts/sin-sync-skills.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# sin-sync-skills.sh — Sync skills to OCI VM fleet
+# Usage: bash scripts/sin-sync-skills.sh [--oci|--help]
+# Author: OpenSIN-AI | License: MIT
+set -euo pipefail
+LOCAL="${HOME}/.config/opencode/skills"
+OCI="ubuntu@92.5.60.87:~/.config/opencode/skills/"
+case "${1:-all}" in --help|-h) echo "Usage: sin-sync-skills.sh [--oci|--help]"; exit 0;; esac
+echo "[SYNC] Syncing to OCI VM..."
+rsync -avz --delete --exclude='*.db' --exclude='*.sqlite*' --exclude='logs/' --exclude='tmp/' --exclude='.cache/' --exclude='auth.json' --exclude='token.json' "${LOCAL}/" "${OCI}" 2>/dev/null && echo "[OK] OCI synced" || echo "[WARN] OCI sync failed"


### PR DESCRIPTION
## Summary
- **install.sh**: One-command installer for OpenCode skill loading (--all/--operations/--knowledge)
- **sin-sync-skills.sh**: Sync skills to OCI VM fleet via rsync
- **convert-to-opencode.py**: Multi-editor config generator (OpenCode, Cursor, Aider)

Closes #5